### PR TITLE
Support installing libsurvive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,3 +247,7 @@ if(CTYPESGEN)
 	add_custom_target(pysurvive COMMAND ${CTYPESGEN} ${CMAKE_SOURCE_DIR}/include/libsurvive/*.h ${INCLUDE_FLAGS} --no-macros -L$<TARGET_FILE_DIR:survive> -llibsurvive.so
 			--strip-prefix=survive_ -P Survive -o ${PYTHON_GENERATED_DIR}pysurvive_generated.py )
 endif()
+
+include(GNUInstallDirs)
+configure_file(survive.pc.in survive.pc @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/survive.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,11 @@ INSTALL(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink survive
 
 install(DIRECTORY include/libsurvive DESTINATION include)
 
+file(GLOB REDIST_HEADERS
+  "redist/*.h"
+)
+install(FILES ${REDIST_HEADERS} DESTINATION include/libsurvive/redist)
+
 find_program(CTYPESGEN ctypesgen PATHS $ENV{HOME}/anaconda3/bin)
 if(CTYPESGEN)
 	get_property(include_directories DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)

--- a/survive.pc.in
+++ b/survive.pc.in
@@ -7,4 +7,4 @@ Name: @CMAKE_PROJECT_NAME@
 Description: Libsurvive
 Version: 0
 Libs: -L${libdir} -lsurvive @EXTRA_LIBS@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/redist

--- a/survive.pc.in
+++ b/survive.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include/libsurvive
+
+Name: @CMAKE_PROJECT_NAME@
+Description: Libsurvive
+Version: 0
+Libs: -L${libdir} -lsurvive @EXTRA_LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
I don't know if this works for windows, if not we can guard it with
```if(CMAKE_SYSTEM_NAME STREQUAL "Linux")``` or so.

With this PR I can build a standalone `api_example.c` with this simple CMakeLists.txt
```cmake
project(survivetest C)
cmake_minimum_required(VERSION 3.6)
add_executable(survivetest api_example.c)
find_package(PkgConfig REQUIRED)
pkg_check_modules(SURVIVE REQUIRED IMPORTED_TARGET survive)
target_link_libraries(survivetest PRIVATE PkgConfig::SURVIVE)
```