### PR TITLE
Include library version in libsurvive target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12.4)
 
-project(libsurvive C CXX)
+project(libsurvive
+	LANGUAGES C CXX
+	VERSION 0.3)
 include(CheckIncludeFile)
 include (CheckSymbolExists)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,7 +51,10 @@ if(USE_HIDAPI OR WIN32)
 endif()
 
 add_library(survive ${SURVIVE_LIBRARY_TYPE} ${SURVIVE_SRCS})
-set_target_properties(survive PROPERTIES FOLDER "libraries")
+set_target_properties(survive PROPERTIES
+	FOLDER "libraries"
+	SOVERSION ${PROJECT_VERSION_MAJOR}
+	VERSION ${PROJECT_VERSION})
 
 target_link_libraries(survive minimal_opencv ${ADDITIONAL_LIBRARIES} mpfit)
 IF(HAVE_ZLIB_H)


### PR DESCRIPTION
Without this linking to libsurvive would fail for e.g. Monado (at least on Alpine Linux):
```
/usr/lib/gcc/x86_64-alpine-linux-musl/10.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: cannot find -lsurvive
```