### PR TITLE
Put comments in the udev file on a new line

### DIFF
--- a/useful_files/81-vive.rules
+++ b/useful_files/81-vive.rules
@@ -20,12 +20,19 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="114d", ATTRS{idProduct}=="8a12", TAG+="uacce
 
 
 #libsurvive
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0bb4", ATTRS{idProduct}=="2c87", MODE="0666" # HTC HMD
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0bb4", ATTRS{idProduct}=="030e", MODE="0666" # HTC HMD Pro(?)
-SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2000", MODE="0666" # Light input
-SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2101", MODE="0666" # Watchman
-SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2012", MODE="0666" # Watchman wired
-SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2022", MODE="0666" # Tracker wired
+# HTC HMD
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0bb4", ATTRS{idProduct}=="2c87", MODE="0666"
+# HTC HMD Pro(?)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0bb4", ATTRS{idProduct}=="030e", MODE="0666"
+# Light input
+SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2000", MODE="0666"
+# Watchman
+SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2101", MODE="0666"
+# Watchman wired
+SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2012", MODE="0666"
+# Tracker wired
+SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2022", MODE="0666"
+# Tracker 2018 wired
 SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2300", MODE="0666" # Tracker 2018 wired
 
 #KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0bb4", ATTR{idProduct}=="2c87", MODE="0666" # HTC


### PR DESCRIPTION
udev doesn't allow rules to have comments on the end

[   35.253978] udevd[2752]: invalid key/value pair in file /usr/lib/udev/rules.d/81-vive.rules on line 23, starting at character 82 ('#')
[   35.253982] udevd[2752]: hint: comments can only start at beginning of line
[   35.253989] udevd[2752]: invalid key/value pair in file /usr/lib/udev/rules.d/81-vive.rules on line 24, starting at character 82 ('#')
[   35.253991] udevd[2752]: hint: comments can only start at beginning of line
[   35.253998] udevd[2752]: invalid key/value pair in file /usr/lib/udev/rules.d/81-vive.rules on line 25, starting at character 82 ('#')
[   35.254000] udevd[2752]: hint: comments can only start at beginning of line
[   35.254006] udevd[2752]: invalid key/value pair in file /usr/lib/udev/rules.d/81-vive.rules on line 26, starting at character 82 ('#')
[   35.254009] udevd[2752]: hint: comments can only start at beginning of line
[   35.254016] udevd[2752]: invalid key/value pair in file /usr/lib/udev/rules.d/81-vive.rules on line 27, starting at character 82 ('#')
[   35.254018] udevd[2752]: hint: comments can only start at beginning of line