### PR TITLE
Added disposal on exit in the Unity example

### DIFF
--- a/bindings/cs/UnityViewer/Assets/SurviveObject.cs
+++ b/bindings/cs/UnityViewer/Assets/SurviveObject.cs
@@ -67,4 +67,12 @@ public class SurviveObject : MonoBehaviour {
 			updatedObject.transform.localRotation = newRotation;
 		}
 	}
+	
+	void OnApplicationQuit() {
+		if (survive != null){
+			survive.Close();
+			survive.Dispose();		
+			survive = null;
+		}
+	}
 }


### PR DESCRIPTION
Just a small check for disposal when exiting Unity. Without this, it's going to crash when Alt+F4-ing out of a build, and (maybe) crash Unity itself when stopping from the editor. 

I am not completely sure about needing all of `Close`, `Dispose` and `= null`.