### PR TITLE
Fixed garbage collection of SurviveSimpleLogFn delegate

### DIFF
--- a/bindings/cs/libsurvive.net/SurviveAPI.cs
+++ b/bindings/cs/libsurvive.net/SurviveAPI.cs
@@ -44,6 +44,7 @@ public class SurviveAPIOObject : IDisposable {
 public class SurviveAPI : IDisposable {
 	protected IntPtr actx;
 	protected bool threadStarted = false;
+	private SurviveSimpleLogFn logFunction;
 
 	public void Dispose() { Close(); }
 
@@ -66,7 +67,9 @@ public class SurviveAPI : IDisposable {
 		if (logFunc == null) {
 			logFunc = InfoEvent;
 		}
-		actx = Cfunctions_api.survive_simple_init_with_logger(args.Length, args, logFunc);
+
+		logFunction = logFunc;
+		actx = Cfunctions_api.survive_simple_init_with_logger(args.Length, args, logFunction);
 
 		if (actx == IntPtr.Zero) {
 			throw new Exception("There was a problem initializing the lib!");


### PR DESCRIPTION
The C# Demo app, and generally C# code, crashes after some time with:
``A callback was made on a garbage collected delegate of type 'libsurvive.net!libsurvive.SurviveSimpleLogFn::Invoke``

this could be after several minutes of runtime. It happens because C# does not see a reference for the log function in the managed side, although it still exists in the native context, so it collects it and then tries to call it.

A simple fix is to just assign a SurviveSimpleLogFn delegate in the SurviveAPI class, so as to keep the handle on the C# side.

Tried it for over an hour of runtime and it works fine.