### PR TITLE
Fix build on systems with no malloc.h (FreeBSD and macOS)

### DIFF
--- a/redist/CNFGWinDriver.c
+++ b/redist/CNFGWinDriver.c
@@ -5,7 +5,9 @@
 #include "CNFGFunctions.h"
 #include <windows.h>
 #include <stdlib.h>
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h> //for alloca
+#endif
 
 static HBITMAP lsBitmap;
 static HINSTANCE lhInstance;

--- a/redist/dirent.windows.h
+++ b/redist/dirent.windows.h
@@ -23,7 +23,9 @@
 #include <wchar.h>
 #include <string.h>
 #include <stdlib.h>
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>

--- a/redist/linmath.c
+++ b/redist/linmath.c
@@ -9,7 +9,9 @@
 #include <string.h>
 
 #include "minimal_opencv.h"
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 #ifndef M_PI
 # define M_PI           3.14159265358979323846  /* pi */

--- a/redist/linmath.h
+++ b/redist/linmath.h
@@ -3,7 +3,9 @@
 #ifndef _LINMATH_H
 #define _LINMATH_H
 
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/redist/lintest.c
+++ b/redist/lintest.c
@@ -4,7 +4,9 @@
 #include <alloca.h>
 #endif
 #include <assert.h>
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <math.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/redist/mpfit/mpfit.c
+++ b/redist/mpfit/mpfit.c
@@ -23,7 +23,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 /* Forward declarations of functions in this module */
 static int mp_fdjac2(mp_func funct, int m, int n, int *ifree, int npar, FLT *x, FLT *fvec, FLT *fjac, int ldfjac,

--- a/src/barycentric_svd/barycentric_svd.c
+++ b/src/barycentric_svd/barycentric_svd.c
@@ -4,7 +4,9 @@
 #include "stdio.h"
 #include "stdlib.h"
 #include "survive.h"
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 #pragma GCC diagnostic ignored "-Wpedantic"
 

--- a/src/lfsr.c
+++ b/src/lfsr.c
@@ -1,6 +1,8 @@
 #include "lfsr.h"
 #include <assert.h>
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <stdbool.h>
 #include <survive.h>
 

--- a/src/lfsr_lh2.c
+++ b/src/lfsr_lh2.c
@@ -17,7 +17,9 @@ uint32_t inline clz(uint32_t value) {
 #endif
 #include "stdio.h"
 #include "string.h"
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 lfsr_poly_t poly_pairs[32] = {
 	// x^17 + x^13 + x^12 + x^10 + x^7 + x^4 + x^2 + x^1 + 1

--- a/src/poser_barycentric_svd.c
+++ b/src/poser_barycentric_svd.c
@@ -1,7 +1,9 @@
 #include "barycentric_svd/barycentric_svd.h"
 #include "math.h"
 #include "minimal_opencv.h"
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <survive.h>

--- a/src/poser_general_optimizer.c
+++ b/src/poser_general_optimizer.c
@@ -3,7 +3,9 @@
 #include "survive_internal.h"
 
 #include <assert.h>
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <stdio.h>
 
 STATIC_CONFIG_ITEM(CONFIG_MAX_ERROR, "max-error", 'f', "Maximum error permitted by poser_general_optimizer.", .01)

--- a/src/poser_mpfit.c
+++ b/src/poser_mpfit.c
@@ -1,6 +1,8 @@
 #include "survive_optimizer.h"
 
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 #include "mpfit/mpfit.h"
 #include "poser.h"

--- a/src/survive_kalman.c
+++ b/src/survive_kalman.c
@@ -1,5 +1,7 @@
 #include "survive_kalman.h"
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <memory.h>
 #include <minimal_opencv.h>
 

--- a/src/survive_kalman_tracker.c
+++ b/src/survive_kalman_tracker.c
@@ -5,7 +5,9 @@
 #include "survive_kalman.h"
 #include "survive_kalman_tracker.h"
 #include <assert.h>
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <memory.h>
 #include <minimal_opencv.h>
 #include <survive_reproject.h>

--- a/src/survive_optimizer.c
+++ b/src/survive_optimizer.c
@@ -12,7 +12,9 @@
 
 #include "mpfit/mpfit.h"
 #include "survive_default_devices.h"
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 STATIC_CONFIG_ITEM(OPTIMIZER_FTOL, "optimizer-ftol", 'f', "Relative chi-square convergence criterium", 0.)
 STATIC_CONFIG_ITEM(OPTIMIZER_XTOL, "optimizer-xtol", 'f', "Relative parameter convergence criterium", 0.0001)

--- a/src/test_cases/check_generated.c
+++ b/src/test_cases/check_generated.c
@@ -21,7 +21,9 @@
 #define M_PI LINMATHPI
 #endif
 
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include "malloc.h"
+#endif
 
 #define STACK_ALLOC(nmembers) (FLT *)alloca(nmembers * sizeof(FLT))
 

--- a/src/test_cases/kalman.c
+++ b/src/test_cases/kalman.c
@@ -6,7 +6,9 @@
 #include <stdlib.h>
 
 #include "../generated/survive_imu.generated.h"
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include "malloc.h"
+#endif
 
 static void rot_predict_quat(FLT t, const survive_kalman_state_t *k, const CvMat *f_in, CvMat *f_out) {
 	(void)k;

--- a/src/test_cases/test_replays.c
+++ b/src/test_cases/test_replays.c
@@ -3,7 +3,9 @@
 #define SURVIVE_ENABLE_FULL_API
 
 #include <complex.h>
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 #include <math.h>
 #include <os_generic.h>
 #include <survive.h>

--- a/survive-solver.c
+++ b/survive-solver.c
@@ -1,4 +1,6 @@
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
 #include <malloc.h>
+#endif
 
 #include "src/survive_default_devices.h"
 #include "survive_optimizer.h"


### PR DESCRIPTION
`malloc.h` is not present on FreeBSD/macOS, don't try to include it