### PR TITLE
lower cmake requirement to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.4)
+cmake_minimum_required(VERSION 3.10)
 
 project(libsurvive
 	LANGUAGES C CXX


### PR DESCRIPTION
This enables building on stock Ubuntu 18.04 without any obvious issues.