### PR TITLE
Change signed one bit field to unsigned

### DIFF
--- a/bindings/python/pysurvive/pysurvive_generated.py
+++ b/bindings/python/pysurvive/pysurvive_generated.py
@@ -1612,7 +1612,7 @@ struct_SurviveObject._fields_ = [
     ('touchmask', c_uint32),
     ('axis', SurviveAxisVal_t * int(16)),
     ('charge', c_int8),
-    ('charging', c_int8, 1),
+    ('charging', c_uint8, 1),
     ('ison', c_uint8, 1),
     ('additional_flags', c_int8, 6),
     ('PoseConfidence', c_double),

--- a/include/libsurvive/survive.h
+++ b/include/libsurvive/survive.h
@@ -114,7 +114,7 @@ struct SurviveObject {
 	SurviveAxisVal_t axis[16];
 
 	int8_t charge;
-	int8_t charging : 1;
+	uint8_t charging : 1;
 	uint8_t ison : 1;
 	int8_t additional_flags : 6;
 


### PR DESCRIPTION
According to C99 standard, section 6.2.6.2, signed one bit field may actually hold only sign bit