### PR TITLE
Build fix

### DIFF
--- a/src/survive_kalman_tracker.c
+++ b/src/survive_kalman_tracker.c
@@ -10,6 +10,7 @@
 #include <malloc.h>
 #endif
 #include <memory.h>
+#include <stddef.h>
 #include <survive_reproject.h>
 #include <survive_reproject_gen2.h>
 


### PR DESCRIPTION
Had a couple of issues building libsurvive locally since 68c77109f2b2268e2857577d3a8a45c9eb6d9d48

- The submodule url was pointing to a local place, it's easier to have the full link to use `git submodules update --init --recursive` or to do a recursive clone

- `stddef.h` was missing to use `offsetof`

```
/home/simon/src/libsurvive/src/survive_kalman_tracker.c: In function 'survive_kalman_tracker_process_noise':
/home/simon/src/libsurvive/src/survive_kalman_tracker.c:657:26: error: implicit declaration of function 'offsetof' [-Werror=implicit-function-declaration]
  657 |         int accBiasIdx = offsetof(SurviveKalmanModel, AccBias)/sizeof(FLT) + i;
      |                          ^~~~~~~~
/home/simon/src/libsurvive/src/survive_kalman_tracker.c:20:1: note: 'offsetof' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
   19 | #include "survive_recording.h"
  +++ |+#include <stddef.h>
   20 | 
```