### PR TITLE
Improve detection/handling of HTC Vive Pro Eye + Wand controllers.

### DIFF
--- a/src/survive_default_devices.c
+++ b/src/survive_default_devices.c
@@ -303,11 +303,12 @@ struct model_number_metadata model_number_subtypes[] = {
 	{"Vive MV", SURVIVE_OBJECT_SUBTYPE_VIVE_HMD, 1.004},
 	{"Vive. MV", SURVIVE_OBJECT_SUBTYPE_VIVE_HMD, 1.004},
 	{"Vive_Pro MV", SURVIVE_OBJECT_SUBTYPE_VIVE_HMD, 1.0028},
+	{"VIVE_Pro MV", SURVIVE_OBJECT_SUBTYPE_VIVE_HMD, 1.0028},
 	{"VIVE Tracker 3.0 MV", SURVIVE_OBJECT_SUBTYPE_TRACKER_GEN2, 1.0034},
 	{"REF-HMD", SURVIVE_OBJECT_SUBTYPE_VIVE_HMD, 1.},
 	{"Tundra Tracker", SURVIVE_OBJECT_SUBTYPE_TRACKER_GEN2, 1.},
 	{"VIVE_Pro 2 MV", SURVIVE_OBJECT_TYPE_HMD, 1.},
-	{"VIVE Controller Pro MV", SURVIVE_OBJECT_TYPE_CONTROLLER, 1.},
+	{"VIVE Controller Pro MV", SURVIVE_OBJECT_SUBTYPE_WAND, 1.},
 };
 
 static int process_jsontok(scratch_space_t *scratch, char *d, stack_entry_t *stack, jsmntok_t *t, int count) {


### PR DESCRIPTION
As tested with a HTC Vive Pro Eye + Wand controllers, this removes a warning about unknown headset name for the "T20" device.

More importantly it fixes input mappings of the Wand controllers delivered with the HMD:

- Grip buttons now work. Before they were dead.
- Menu buttons now work. Before they were dead.
- Touching the touchpad correctly registers as touch instead of click.