### PR TITLE
Fix windows wireless dongle setup

### DIFF
--- a/src/driver_vive.c
+++ b/src/driver_vive.c
@@ -218,14 +218,17 @@ static uint8_t vive_magic_power_off[] = {
 static uint8_t vive_magic_raw_mode_1[] = {VIVE_REPORT_CHANGE_MODE, 0x01, 0x00, 0x00, 0x00};
 static uint8_t vive_request_version_info[] = {VIVE_REPORT_VERSION};
 
-static uint8_t vive_magic_rf_raw_mode_0[] = {
+// Windows needs 64 size for the wireless dongle
+static uint8_t vive_magic_rf_raw_mode_0[64] = {
 	VIVE_REPORT_COMMAND, VIVE_COMMAND_CHANGE_PROTOCOL, 0x6, 0x01, 0x00, 0x00, 0x02, 0x00, 0x00};
 static uint8_t vive_magic_rf_raw_mode_1[] = {
 	VIVE_REPORT_COMMAND, VIVE_COMMAND_CHANGE_PROTOCOL, 0x6, 0x01, 0x01, 0x00, 0x02, 0x00, 0x00};
-static uint8_t vive_magic_protocol_switch[] = {
+// Windows needs 64 size for the wireless dongle
+static uint8_t vive_magic_protocol_switch[64] = {
 	VIVE_REPORT_COMMAND, VIVE_COMMAND_CHANGE_PROTOCOL, 0x3, 0x00, 0x01, 0x00};
 static uint8_t vive_request_pairing[] = {VIVE_REPORT_COMMAND, VIVE_COMMAND_PAIR, 0x03, 0x01, 0x10, 0x27};
-static uint8_t vive_magic_protocol_super_magic[] = {VIVE_REPORT_COMMAND,
+// Windows needs 64 size for the wireless dongle
+static uint8_t vive_magic_protocol_super_magic[64] = {VIVE_REPORT_COMMAND,
 													VIVE_COMMAND_CONFIGURE_RADIO,
 													0x10,
 													0xbe,

--- a/src/driver_vive.hidapi.h
+++ b/src/driver_vive.hidapi.h
@@ -171,8 +171,10 @@ static survive_usb_device_t get_next_device(survive_usb_device_enumerator* d, su
 		return *d = head;
 	}
 	
+	// On Windows the wireless dongle interface is -1
+	// That's why we check for <= 0
 	for (survive_usb_device_t c = (*d)->next; c; c = c->next) {
-		if (c->interface_number == 0) {
+		if (c->interface_number <= 0) {
 			return *d = c; 
 		}
 	}


### PR DESCRIPTION
Fixes #283 and set the size of magic buffers used for the wireless dongle. This is needed otherwise we only get -1 and can't complete the setup.

Not sure if these changes works on Linux. It would be nice if someone with Linux could test before merging.