### PR TITLE
Update Debian build instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Table of Contents
 
 ## Debian
 ```
-git clone git@github.com:cntools/libsurvive.git --recursive
+git clone https://github.com/cntools/libsurvive.git --recursive
 cd libsurvive
 sudo cp ./useful_files/81-vive.rules /etc/udev/rules.d/
-sudo udevadm control --reload-rules && udevadm trigger
-sudo apt-get install build-essential zlib1g-dev libx11-dev libusb-1.0-0-dev freeglut3-dev liblapacke-dev libopenblas-dev libatlas-base-dev cmake
+sudo udevadm control --reload-rules && sudo udevadm trigger
+sudo apt update && sudo apt install build-essential zlib1g-dev libx11-dev libusb-1.0-0-dev freeglut3-dev liblapacke-dev libopenblas-dev libatlas-base-dev cmake
 make
 ```
 


### PR DESCRIPTION
- Change to https git URL, since SSH requires extra configuration.
- `udevadm trigger` needs to be run a root as well.
- APT should be updated before installing to prevent an outdated package cache.
- Change to `apt` since it is shorter.