### PR TITLE
Revive the survive_in_catkin_make property, if built using catkin_make or catkin_tools

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,13 +2,16 @@ if(OPENVR_LIBRARIES AND NOT USE_SINGLE_PRECISION)
   add_subdirectory(openvr_driver)
 endif()
 
-find_package(catkin QUIET COMPONENTS
-  roscpp
-  geometry_msgs)
+get_property(survive_in_catkin_make GLOBAL PROPERTY SURVIVE_IN_CATKIN_MAKE)
 
-IF(catkin_DIR)
-  add_subdirectory(ros_publisher)
-ENDIF()
+if(NOT survive_in_catkin_make)
+  find_package(catkin QUIET COMPONENTS
+    roscpp
+    geometry_msgs)
+  IF(catkin_DIR)
+    add_subdirectory(ros_publisher)
+  ENDIF()
+endif()
 
 find_library(XDO_LIB xdo)
 if(XDO_LIB)


### PR DESCRIPTION
Revive survive in catkin make build property, for the ability to use catkin_tools to build survive_publisher. Property was originally added in https://github.com/cntools/libsurvive/commit/42bfce9e1fc54a2ab53bf15ae835882f449a60d8, but functionality was lost during CMakeLists.txt refactor, whether intentional or not.

With this change, libsurvive can be put in a catkin workspace, and be built simply by running ``catkin build``. Without this change, the CMakeLists.txt will have a circular inclusion.