### PR TITLE
apply patch from MPFit v1.4

### DIFF
--- a/redist/mpfit/mpfit.c
+++ b/redist/mpfit/mpfit.c
@@ -1263,7 +1263,7 @@ static int mp_fdjac2(mp_func funct, int m, int n, int *ifree, int npar, FLT *x, 
 				if (!debug) {
 					/* Non-debug path for speed */
 					for (i = 0; i < m; i++, ij++) {
-						fjac[ij] = (fjac[ij] - wa[i]) / (2 * h); /* fjac[i+m*j] */
+						fjac[ij] = (wa2[ij] - wa[i]) / (2 * h); /* fjac[i+m*j] */
 					}
 				} else {
 					/* Debug path for correctness */


### PR DESCRIPTION
In some cases the MPFit fitting procedures (used in `poser_mpfit.c`) fails as there are some Not-a-Numbers in the processing. This pull request solves this issue for me (see  #277 )

The patch was provided by the developers of MPFit in 2020. I brought it into the adapted version of `mpfit.c` in libsurvive.

See https://pages.physics.wisc.edu/~craigm/idl/cmpfit.html