### PR TITLE
Fix infinite loop in vive driver usb shutdown

### DIFF
--- a/src/driver_vive.hidapi.h
+++ b/src/driver_vive.hidapi.h
@@ -194,6 +194,7 @@ static inline void survive_close_usb_device(struct SurviveUSBInfo *usbInfo) {
 		OGJoinThread(sv->udev[i].interfaces->servicethread);
 	}
 #endif
+	usbInfo->request_close = true;
 }
 
 void survive_usb_close(SurviveViveData *sv) {}


### PR DESCRIPTION
Fixes infinite loop during vive driver shutdown.
`survive_handle_close_request_flag` in drive_vive.c never shutdown the usb connection because `usbInfo.requestClose` was never `true`.

I updated `survive_close_usb_device` to set the `requestClose` flag to true so `survive_handle_close_request_flag` can react to it and close the connection.

I am not 100% sure where this flag is supposed to be set but from my understanding `survive_close_usb_device` should be reasonable and so far the plugin seems to shutdown gracefully.

Fixes #312 