### PR TITLE
Reconnect tracker after turn off and on

### DIFF
--- a/src/driver_global_scene_solver.c
+++ b/src/driver_global_scene_solver.c
@@ -62,6 +62,32 @@ static size_t add_scenes(struct global_scene_solver *gss, SurviveObject *so) {
 
 	SurviveSensorActivations *activations = &so->activations;
 
+	// TT clean up scenes with invalid SurviveObjects
+	unsigned int free_idx = 0;
+	for (int i = 0; i < GSS_NUM_STORED_SCENES; i++) {
+		if (gss->scenes[i].so == NULL) {
+			continue;
+		}
+		
+		bool is_still_valid = false;
+		if (gss->scenes[i].so == so) {
+			is_still_valid = true;
+		}
+		for (int j = 0; j < ctx->objs_ct; j++) {
+			if (gss->scenes[i].so == ctx->objs[j]) {
+				is_still_valid = true;
+			}
+		}
+
+		if (is_still_valid) {
+			gss->scenes[free_idx].so = gss->scenes[i].so;
+			free_idx++;
+		} else {
+			SV_WARN("in GlobalSceneSolver: deleted scene %d with SurviveObject at adress &%p", i, (void* )so);
+		}
+	}
+	gss->scenes_cnt = free_idx;
+
 	struct PoserDataGlobalScene *scene = &gss->scenes[gss->scenes_cnt % GSS_NUM_STORED_SCENES];
 
 	scene->pose = so->OutPoseIMU;

--- a/src/driver_vive.c
+++ b/src/driver_vive.c
@@ -472,6 +472,18 @@ static int AttachInterface(SurviveViveData *sv, struct SurviveUSBInfo *usbObject
 						   USBHANDLE devh, usb_callback cb);
 static int survive_vive_send_haptic(SurviveObject *so, FLT frequency, FLT amplitude, FLT duration_seconds);
 
+static bool survive_device_is_rf(const struct DeviceInfo *device_info) {
+	switch (device_info->type) {
+	case USB_DEV_HMD:
+	case USB_DEV_HMD_IMU_LH:
+	case USB_DEV_W_WATCHMAN1:
+	case USB_DEV_TRACKER0:
+	case USB_DEV_TRACKER1:
+		return false;
+	}
+	return true;
+}
+
 #ifdef HIDAPI
 #include "driver_vive.hidapi.h"
 #else
@@ -505,18 +517,6 @@ struct survive_config_packet {
 };
 
 #include "driver_vive.config.h"
-
-static bool survive_device_is_rf(const struct DeviceInfo *device_info) {
-	switch (device_info->type) {
-	case USB_DEV_HMD:
-	case USB_DEV_HMD_IMU_LH:
-	case USB_DEV_W_WATCHMAN1:
-	case USB_DEV_TRACKER0:
-	case USB_DEV_TRACKER1:
-		return false;
-	}
-	return true;
-}
 
 static struct SurviveUSBInfo *survive_get_usb_info(SurviveObject *so) { return (struct SurviveUSBInfo *)so->driver; }
 

--- a/src/driver_vive.libusb.h
+++ b/src/driver_vive.libusb.h
@@ -214,7 +214,8 @@ static void handle_transfer(struct libusb_transfer *transfer) {
 	SurviveContext *ctx = iface->ctx;
 	if (!iface->shutdown && transfer->status == LIBUSB_TRANSFER_TIMED_OUT) {
         iface->consecutive_timeouts++;
-        if(iface->consecutive_timeouts >= 3) {
+		bool is_rf_device = survive_device_is_rf(iface->usbInfo->device_info);
+        if(iface->consecutive_timeouts >= 3 || is_rf_device) {
             SV_WARN("%f %s Device turned off: %d", survive_run_time(ctx), survive_colorize_codename(iface->assoc_obj),
                     transfer->status);
             goto object_turned_off;


### PR DESCRIPTION
When turning a watchman-connected tracker device off and on again, the global scene solver failed due to some old scenes and the `handle_transfer` function in `src/driver_vive.libusb.h` did not go to the `object_turned_off` label. More info in #314.