### PR TITLE
variance_measure_add: skip non-finite input instead of asserting

### DIFF
--- a/redist/variance.h
+++ b/redist/variance.h
@@ -12,10 +12,21 @@ static inline void variance_measure_add(struct variance_measure *meas, const FLT
 	if (meas->size == 0)
 		meas->size = 1;
 
+	/* Guard against non-finite values. Corrupt optical angles (e.g. bad FPGA
+	 * timestamps during USB disturbances) can reach here as NaN or Inf. The
+	 * assert below would crash the process and corrupt the on-disk config;
+	 * dropping one sample is strictly safer and has negligible effect on the
+	 * variance estimate. */
+	for (int i = 0; i < meas->size; i++) {
+		if (!isfinite(d[i])) {
+			fprintf(stderr, "[libsurvive] variance_measure_add: non-finite d[%d]=%f, dropping measurement\n", i, (double)d[i]);
+			return;
+		}
+	}
+
 	meas->n++;
 	addnd(meas->sum, meas->sum, d, meas->size);
 	for (int i = 0; i < meas->size; i++) {
-		assert(isfinite(d[i]));
 		meas->sumSq[i] += d[i] * d[i];
 	}
 }


### PR DESCRIPTION
## Summary

`variance_measure_add` contains an `assert(isfinite(d[i]))` inside the accumulation loop. When corrupt optical angle data reaches this function, the assert fires, crashes the process with `SIGABRT`, and corrupts the on-disk `config.json` because the file is left in a partially-written state. The next launch then fails to parse config and crashes again — a boot loop.

Dropping one non-finite sample has negligible effect on the variance estimate. Crashing and corrupting config does not.

## Demonstration

Hardware trigger: a USB disturbance (cable flex, port brown-out) causes the FPGA to emit bad timestamps. The driver produces a non-finite optical angle. That angle propagates into `variance_tracker_add` → `variance_measure_add`:

BEFORE fix:
d[0] = NaN
assert(isfinite(NaN))  → fires
Process: SIGABRT
config.json: partially written, unparseable on next launch
Result: crash loop until config.json is manually deleted

AFTER fix:
d[0] = NaN
isfinite(NaN) == false → early return, measurement skipped
stderr: "[libsurvive] variance_measure_add: non-finite d[0]=nan, dropping measurement"
Process: continues normally
Result: one sample dropped, variance estimate unaffected



The assert was presumably added as a correctness guard during development. In production, it turns a transient hardware glitch into a persistent failure requiring manual intervention.

## Impact

Any caller passing data derived from optical angles is exposed. `variance_tracker_add` in `redist/variance.h` is the primary path; it is called from lighthouse calibration and pose confidence tracking. On hardware that experiences any USB instability, this assert is reachable.

## Change

One file, `redist/variance.h`. The assert is replaced with a pre-check that returns early and logs to stderr. The accumulator (`meas->n`, `meas->sum`, `meas->sumSq`) is left unchanged, which is correct — including a non-finite value in any of those fields would corrupt all subsequent variance calculations derived from this accumulator.

## Found via

Observed in production: tracker running on embedded hardware (Raspberry Pi, USB bus under load) would enter a crash loop after a cable disturbance. `coredumpctl` showed `SIGABRT` inside `variance_measure_add`. Deleting `config.json` recovered the system; the underlying assert was the cause.