### PR TITLE
kalman: cap process noise dt to prevent t^7 explosion on tracking gaps

### DIFF
--- a/src/survive_kalman_tracker.c
+++ b/src/survive_kalman_tracker.c
@@ -944,6 +944,9 @@ void survive_kalman_tracker_process_noise(const struct SurviveKalmanTracker_Para
 	 * positional model with a second order rotational model with tuning parameters
 	 */
 
+	/* dt is capped to prevent NaN/inf values */
+	if (t > 0.05) t = 0.05;
+
 	FLT t2 = t * t;
 	FLT t3 = t2 * t;
 	FLT t4 = t3 * t;


### PR DESCRIPTION
## Summary

`survive_kalman_tracker_process_noise` computes a Q matrix with terms up to t⁷ (jerk model). When tracking is interrupted — lighthouse occlusion, USB dropout, cold start — the `dt` passed to this function can be large enough that t⁷ overflows into Inf/NaN. The filter then rejects all subsequent valid observations and the tracker freezes until the process is restarted.

Closes #346.

## Demonstration

Normal IMU interval is ~8ms (t = 0.008). Consider a 1-second blackout:

t = 1.0s (blackout or cold start gap)

BEFORE fix:
t^7 = 1.0^7 = 1.0
Q_jerk[0] = t^7 / 252 = 0.00397         ← finite but large
... longer gap (t = 2s):
t^7 = 128.0
Q entries → Inf/NaN
Next filter update: quatrotateabout assertion fires or observations rejected
Result: tracker frozen, restart required

AFTER fix:
t capped at 0.05s before power series
t^7 = 0.05^7 = 7.8e-10                  ← uncertainty growth bounded
State prediction unaffected (uses real dt)
Result: filter widens uncertainty to a finite maximum, resumes tracking
on next valid observation


The cap does not affect normal tracking. At the 8ms IMU rate, t = 0.008 << 0.05, so the cap is never active during steady-state operation.

## Why 50ms

50ms is 5–6× the normal IMU interval and well below any plausible legitimate tracking gap. It bounds t⁷ at `0.05^7 ≈ 7.8e-10`, keeping all Q entries finite and reasonable. This matches standard practice for discrete continuous-time process noise models: large gaps should widen uncertainty to a finite maximum, not to infinity.

## Impact

Any scenario with a tracking gap longer than ~200–300ms is affected: lighthouse occlusion (the specific case in #346), USB cable disturbance, cold start with delayed first IMU packet. The symptom is always the same: filter enters a degenerate state and stops accepting observations.

## Change

One file, one line in `src/survive_kalman_tracker.c`. State prediction is not touched; only the Q matrix computation is bounded.