### PR TITLE
solve_global_scene: treat MP_MAXITER as calibration failure

### DIFF
--- a/src/poser_mpfit.c
+++ b/src/poser_mpfit.c
@@ -957,7 +957,10 @@ bool solve_global_scene(struct SurviveContext *ctx, MPFITData *d, PoserDataGloba
 
 	survive_get_ctx_lock(ctx);
 	survive_recording_write_matrix(ctx->recptr, 0, 5, "GSS", &R);
-	bool status_failure = res <= 0;
+	/* MP_MAXITER means the solver exhausted its iteration budget without
+	 * converging. The result is an intermediate, unconverged pose — treat it
+	 * as a failure so the bad lighthouse positions are not written to disk. */
+	bool status_failure = res <= 0 || res == MP_MAXITER;
 	FLT sensor_covariance = d->sensor_variance * d->sensor_variance;
 	FLT sensor_error = sqrtf(mpfitctx.stats.sensor_error / mpfitctx.stats.sensor_error_cnt);
 	if (status_failure || sensor_error > d->opt.max_cal_error) {


### PR DESCRIPTION
## Summary

`solve_global_scene` uses `res <= 0` to detect solver failure, but `MP_MAXITER` (return code 5) is not ≤ 0. When the GSS solver hits its iteration limit without converging, `status_failure` is false, the unconverged lighthouse positions are accepted, and they are written to disk.

On the next launch those positions are loaded as the starting point for calibration. If the unconverged solve is significantly wrong, all subsequent tracking is corrupted and the only recovery is to delete `config.json`.

## Demonstration

BEFORE fix:
GSS solver hits iteration limit
res = MP_MAXITER (5)
res <= 0 → false
status_failure = false
Unconverged lighthouse positions written to disk
Next launch: loads bad positions → tracking corrupted
Result: config.json must be deleted to recover

AFTER fix:
GSS solver hits iteration limit
res = MP_MAXITER (5)
res <= 0 || res == MP_MAXITER → true
status_failure = true
GSS result discarded, existing positions preserved
Result: calibration retried on next GSS cycle



The regular per-object pose solver (line ~522) already rejects `res <= 0` correctly; `solve_global_scene` was missing the `MP_MAXITER` case.

## Impact

Any deployment that triggers GSS calibration (lighthouse position solving) is exposed. The failure mode is silent. No crash, no warning, but tracking quality degrades permanently until config is cleared. More likely on resource-constrained hardware (embedded, Pi) where the solver may not converge within the default iteration budget.

## Change

One line in `src/poser_mpfit.c`, inside `solve_global_scene` only. The per-object pose solver is not touched.

## Found via

Observed in production: GSS calibration would occasionally produce wildly wrong lighthouse positions that persisted across restarts. Correlating with solver return codes showed `MP_MAXITER` returns were being silently accepted. Deleting `config.json` recovered tracking; adding `res == MP_MAXITER` to the failure condition prevented recurrence.