### PR TITLE
driver_vive: downgrade unknown lightcap report from error to warning

### DIFF
--- a/src/driver_vive.c
+++ b/src/driver_vive.c
@@ -3106,8 +3106,8 @@ void survive_data_cb_locked(uint64_t time_received_us, SurviveUSBInterface *si) 
 		} else if (id == VIVE_REPORT_USB_TRACKER_LIGHTCAP_V1) {
 			SV_INFO("USB lightcap report is of an unexpected type for %s: %d (0x%02x)", obj->codename, id, id);
 		} else {
-			SV_ERROR(SURVIVE_ERROR_HARWARE_FAULT, "USB lightcap report is of an unknown type for %s: %d (0x%02x)",
-					 obj->codename, id, id);
+			SV_WARN("USB lightcap report is of an unknown type for %s: %d (0x%02x); ignoring",
+					obj->codename, id, id);
 		}
 
 		break;


### PR DESCRIPTION
## Summary

`survive_data_cb_locked` calls `SV_ERROR(SURVIVE_ERROR_HARWARE_FAULT, ...)` when it receives a USB lightcap report ID it doesn't recognise. `SV_ERROR` terminates the process. New tracker firmware routinely emits report IDs that older libsurvive versions don't know about — this makes libsurvive incompatible with any firmware newer than the version it was built against.

The adjacent `VIVE_REPORT_USB_TRACKER_LIGHTCAP_V1` case already handles a similar situation with `SV_INFO` and ignores the packet. The unknown-ID case should do the same.

## Demonstration

BEFORE fix:
Tracker firmware updated, emits new report ID 0xNN
libsurvive: SV_ERROR(SURVIVE_ERROR_HARWARE_FAULT, "unknown type ... 0xNN")
Process: terminated
Result: tracking dead after firmware upgrade, requires libsurvive rebuild

AFTER fix:
Tracker firmware updated, emits new report ID 0xNN
libsurvive: SV_WARN("unknown type ... 0xNN; ignoring")
Packet dropped, all known report types continue processing normally
Result: tracking continues; unknown packet logged once for diagnostics



## Impact

Any deployment that runs firmware newer than the libsurvive build is exposed. SteamVR regularly pushes tracker firmware updates; users who update firmware without recompiling libsurvive will hit this immediately.

## Change

One file, `src/driver_vive.c`. `SV_ERROR(SURVIVE_ERROR_HARWARE_FAULT, ...)` replaced with `SV_WARN(...)`. The message gains `"; ignoring"` to make it clear the packet is dropped and tracking continues.

## Found via

Observed in production: tracker firmware update caused libsurvive to terminate on first lightcap packet with `SURVIVE_ERROR_HARWARE_FAULT`. The new firmware emitted a report ID not present in the known-ID list. Rolling back firmware restored operation; this patch restores forward compatibility without requiring a firmware rollback or libsurvive rebuild.