### PR TITLE
driver_vive: clear_halt before submit_transfer in AttachInterface

### DIFF
--- a/src/driver_vive.c
+++ b/src/driver_vive.c
@@ -726,6 +726,9 @@ static int AttachInterface(SurviveViveData *sv, struct SurviveUSBInfo *usbObject
 								   0);
 
 	iface->last_submit_time = OGGetAbsoluteTimeUS();
+
+	libusb_clear_halt(devh, endpoint_num);
+
 	int rc = libusb_submit_transfer(tx);
 	if (rc) {
 		SV_ERROR(SURVIVE_ERROR_HARWARE_FAULT, "Error: Could not submit transfer for %s 0x%02x (Code %d, %s)", hname,


### PR DESCRIPTION
## Summary

`AttachInterface` calls `libusb_submit_transfer()` without first clearing any halt condition on the endpoint. If the endpoint is stalled — from a previous session, a failed transfer, or a device re-enumeration — the submit returns `LIBUSB_ERROR_PIPE` (-9) and the interface attachment fails silently.

## Demonstration

**BEFORE** — `AttachInterface` in `src/driver_vive.c`:
```c
iface->last_submit_time = OGGetAbsoluteTimeUS();
int rc = libusb_submit_transfer(tx);
if (rc) {
    SV_ERROR(SURVIVE_ERROR_HARWARE_FAULT, "Error: Could not submit transfer …");
    return 6;
}
```

**AFTER**:
```c
iface->last_submit_time = OGGetAbsoluteTimeUS();

libusb_clear_halt(devh, endpoint_num);

int rc = libusb_submit_transfer(tx);
```

## Impact

Without this, any stalled endpoint causes `AttachInterface` to fail with `LIBUSB_ERROR_PIPE`. The device appears to open successfully but receives no data. The fix matches standard libusb practice: always clear halt before the first submit.

## Change

One call to `libusb_clear_halt(devh, endpoint_num)` before `libusb_submit_transfer()` in the libusb path of `AttachInterface`.

## Found via

Observed on hardware after device re-enumeration left an endpoint halted; `libusb_submit_transfer` returned -9 and tracking never started.
