### PR TITLE
poser_mpfit: Skip disabled lighthouses to prevent matrix assertion fa…

### DIFF
--- a/src/poser_mpfit.c
+++ b/src/poser_mpfit.c
@@ -165,6 +165,10 @@ static size_t construct_input_from_scene(const MPFITData *d, survive_long_timeco
 			continue;
 		}
 
+		if (ctx->bsd[lh].disable) {
+			continue;
+		}
+
 		if (!ctx->bsd[lh].PositionSet && (!isStationary || !ctx->bsd[lh].OOTXSet)) {
 			continue;
 		}
@@ -662,6 +666,9 @@ static void handle_results(MPFITData *d, PoserDataLight *lightData, FLT error, S
 			estimate->Pos[2] = 0;
 
 			for (int i = 0; i < so->ctx->activeLighthouses; i++) {
+				if (so->ctx->bsd[i].disable) {
+					continue; 
+				}
 				SurvivePose new_pos = *survive_get_lighthouse_position(so->ctx, i);
 				if (so->ctx->bsd[i].PositionSet) {
 					new_pos.Pos[2] -= adjust;
@@ -831,6 +838,9 @@ bool solve_global_scene(struct SurviveContext *ctx, MPFITData *d, PoserDataGloba
 		SV_VERBOSE(10, "Scene with pose (%s) " SurvivePose_format " %6.4f", mpfitctx.sos[i]->codename,
 				   SURVIVE_POSE_EXPAND(gss->scenes[i].pose), fabs(err_up[2] - 1.));
 		for (int j = 0; j < gss->scenes[i].meas_cnt; j++) {
+			if(ctx->bsd[gss->scenes[i].meas[j].lh].disable) {
+				continue; 
+			}
 			survive_optimizer_measurement *meas =
 				survive_optimizer_emplace_meas(&mpfitctx, survive_optimizer_measurement_type_light);
 			meas->light.object = i;
@@ -848,6 +858,9 @@ bool solve_global_scene(struct SurviveContext *ctx, MPFITData *d, PoserDataGloba
 	}
 
 	for (int i = 0; i < ctx->activeLighthouses; i++) {
+		if (ctx->bsd[i].disable) {
+			continue; 
+		} 
 		if (lh_meas[i] > 0)
 			SV_VERBOSE(10, "%d %d Measurements for %d", (int)lh_meas[i][0], (int)lh_meas[i][1], i);
 
@@ -931,6 +944,9 @@ bool solve_global_scene(struct SurviveContext *ctx, MPFITData *d, PoserDataGloba
 	}
 
 	for (int i = 0; i < ctx->activeLighthouses; i++) {
+		if (ctx->bsd[i].disable) {
+			continue;
+		}
 		if (quatiszero(survive_optimizer_get_camera(&mpfitctx)[i].Rot)) {
 			// survive_optimizer_fix_camera(&mpfitctx, i);
 			if (lh_meas[i][0] < 5 || lh_meas[i][1] < 5) {


### PR DESCRIPTION
This fixes a crash when disabled lighthouses are used:

Assertion failed in cn_matrix.h:234: cn_matrix_idx: (unsigned)row < (unsigned)mat->rows

Root cause:
Disabled lighthouses were still processed in global scene solving, leading to invalid matrix operations.

Changes:
Added checks for `ctx->bsd[lh].disable` in:
- construct_input_from_scene
- handle_results
- solve_global_scene

Skipping disabled lighthouses prevents the crash and keeps the solver stable.