### PR TITLE
mp_fdjac2: guard non-finite numerical derivatives

### DIFF
--- a/redist/mpfit/mpfit.c
+++ b/redist/mpfit/mpfit.c
@@ -1228,14 +1228,16 @@ static int mp_fdjac2(mp_func funct, int m, int n, int *ifree, int npar, FLT *x, 
 					/* Non-debug path for speed */
 					for (i = 0; i < m; i++, ij++) {
 						fjac[ij] = (wa[i] - fvec[i]) / h; /* fjac[i+m*j] */
-						assert(isfinite(fjac[ij]));
+						if (!isfinite(fjac[ij]))
+							fjac[ij] = 0;
 					}
 				} else {
 					/* Debug path for correctness */
 					for (i = 0; i < m; i++, ij++) {
 						FLT fjold = fjac[ij];
 						fjac[ij] = (wa[i] - fvec[i]) / h; /* fjac[i+m*j] */
-						assert(isfinite(fjac[ij]));
+						if (!isfinite(fjac[ij]))
+							fjac[ij] = 0;
 						if ((da == 0 && dr == 0 && (fjold != 0 || fjac[ij] != 0)) ||
 							((da != 0 || dr != 0) && (fabs(fjold - fjac[ij]) > da + fabs(fjold) * dr))) {
 							fprintf(stderr, "   %10d %10.4g %10.4g %10.4g %10.4g %10.4g\n", i, fvec[i], fjold, fjac[ij],
@@ -1264,6 +1266,8 @@ static int mp_fdjac2(mp_func funct, int m, int n, int *ifree, int npar, FLT *x, 
 					/* Non-debug path for speed */
 					for (i = 0; i < m; i++, ij++) {
 						fjac[ij] = (wa2[ij] - wa[i]) / (2 * h); /* fjac[i+m*j] */
+						if (!isfinite(fjac[ij]))
+							fjac[ij] = 0;
 					}
 				} else {
 					/* Debug path for correctness */


### PR DESCRIPTION
## Summary

`mp_fdjac2`'s only protection against a non-finite finite-difference derivative is `assert(isfinite(fjac[ij]))`, which a release build (`-DNDEBUG`) strips out entirely — and the two-sided derivative path has no check at all. If the user function returns a degenerate residual for some parameter value, `wa[i]`/`fvec[i]` can be non-finite, writing NaN/Inf straight into `fjac`.

That NaN then poisons `fnorm`/`ratio` in `mpfit()`'s outer Levenberg-Marquardt loop. Since any comparison against NaN is false, the iteration counter (which only advances inside the `ratio>=p0001` success branch) never increments, so the `maxiter` check that's supposed to bound the loop never fires.

## Demonstration

BEFORE fix:
User function returns a degenerate residual for some trial parameter value
mp_fdjac2: writes NaN/Inf into fjac (assert is a no-op under -DNDEBUG)
mpfit(): outer loop's ratio comparison against NaN is always false
Iteration counter never advances; maxiter check never fires
Result: solver thread spins indefinitely instead of returning MP_MAXITER

AFTER fix:
User function returns a degenerate residual for some trial parameter value
mp_fdjac2: detects non-finite fjac, sanitizes to 0
mpfit(): column treated as having no measurable gradient (same fallback mp_qrfac already uses for a zero-norm column)
Result: solver proceeds normally and returns a clean status (success or MP_MAXITER), never hangs

## Impact

Any caller whose residual function can produce a degenerate/non-finite value for some parameter trial is exposed — e.g. a rank-deficient or otherwise ill-posed fit reached transiently during normal operation (in our case, immediately after a scene/calibration reset). On a release build this manifests as a CPU-pinned thread that never returns and never logs anything, rather than a clean failure return, since the only existing guard (`assert`) is compiled out.

## Change

One file, `redist/mpfit/mpfit.c`, function `mp_fdjac2`. Added `if (!isfinite(fjac[ij])) fjac[ij] = 0;` immediately after each of the three places `fjac[ij]` is computed from a finite-difference (one-sided non-debug, one-sided debug, two-sided non-debug), ahead of the existing `assert` where one exists.

## Found via

Reproduced on real hardware (Raspberry Pi 4B running the GSS/MPFIT poser): after a tracker reinit while actively tracking, the GSS solver thread would intermittently spin at ~95-100% CPU for several minutes with zero log output, confirmed via gdb thread dumps (stuck inside mpfit() → mp_fdjac2, FPU status register showing divide-by-zero/invalid-operation flags set, ~465k spin iterations/sec with no progress). 

Notably, the same libsurvive build reproduced this reliably on one Raspberry Pi OS release but not on an earlier one under the identical trigger sequence — we were unable to identify a specific OS-level change responsible (kernel, systemd/udev, and firmware/EEPROM package diffs between the releases were all ruled out), which suggests the divide-by-zero is being reached via a timing-sensitive path rather than anything OS-version-specific in nature, but doesn't rule one out. This patch closes the gap regardless of root timing cause and has held up under repeated reinit-while-tracking testing and an overnight soak on the affected hardware.
