### PR TITLE
Fix typo in survive_simple_object_charge_percet (percent)

### DIFF
--- a/include/libsurvive/survive_api.h
+++ b/include/libsurvive/survive_api.h
@@ -136,7 +136,7 @@ SURVIVE_EXPORT bool survive_simple_object_charging(const SurviveSimpleObject *sa
 /**
  * @return The object charge percent from 0 to 100
  */
-SURVIVE_EXPORT uint8_t survive_simple_object_charge_percet(const SurviveSimpleObject *sao);
+SURVIVE_EXPORT uint8_t survive_simple_object_charge_percent(const SurviveSimpleObject *sao);
 
 /**
  * Gets the null terminated name of the object.

--- a/src/survive_api.c
+++ b/src/survive_api.c
@@ -480,7 +480,7 @@ SURVIVE_EXPORT bool survive_simple_object_charging(const SurviveSimpleObject *sa
 	}
 }
 
-SURVIVE_EXPORT uint8_t survive_simple_object_charge_percet(const SurviveSimpleObject *sao) {
+SURVIVE_EXPORT uint8_t survive_simple_object_charge_percent(const SurviveSimpleObject *sao) {
 	switch (sao->type) {
 	case SurviveSimpleObject_LIGHTHOUSE: {
 		return 100;


### PR DESCRIPTION
Fix function typo, close relevant issue:
[github.com/collabora/libsurvive/issues/337](url)