### PR TITLE
 Backwards compatibility for misspelled method name 

### DIFF
--- a/include/libsurvive/survive_api.h
+++ b/include/libsurvive/survive_api.h
@@ -136,7 +136,7 @@ SURVIVE_EXPORT bool survive_simple_object_charging(const SurviveSimpleObject *sa
 /**
  * @return The object charge percent from 0 to 100
  */
-SURVIVE_EXPORT uint8_t survive_simple_object_charge_percet(const SurviveSimpleObject *sao);
+SURVIVE_EXPORT uint8_t survive_simple_object_charge_percent(const SurviveSimpleObject *sao);
 
 /**
  * Gets the null terminated name of the object.

--- a/include/libsurvive/survive_api.h
+++ b/include/libsurvive/survive_api.h
@@ -139,6 +139,12 @@ SURVIVE_EXPORT bool survive_simple_object_charging(const SurviveSimpleObject *sa
 SURVIVE_EXPORT uint8_t survive_simple_object_charge_percent(const SurviveSimpleObject *sao);
 
 /**
+ * @deprecated Misspelled name kept for backwards compatibility; use
+ * survive_simple_object_charge_percent() instead.
+ */
+SURVIVE_EXPORT uint8_t survive_simple_object_charge_percet(const SurviveSimpleObject *sao);
+
+/**
  * Gets the null terminated name of the object.
  */
 SURVIVE_EXPORT const char *survive_simple_object_name(const SurviveSimpleObject *sao);

--- a/src/survive_api.c
+++ b/src/survive_api.c
@@ -480,7 +480,7 @@ SURVIVE_EXPORT bool survive_simple_object_charging(const SurviveSimpleObject *sa
 	}
 }
 
-SURVIVE_EXPORT uint8_t survive_simple_object_charge_percet(const SurviveSimpleObject *sao) {
+SURVIVE_EXPORT uint8_t survive_simple_object_charge_percent(const SurviveSimpleObject *sao) {
 	switch (sao->type) {
 	case SurviveSimpleObject_LIGHTHOUSE: {
 		return 100;

--- a/src/survive_api.c
+++ b/src/survive_api.c
@@ -494,6 +494,11 @@ SURVIVE_EXPORT uint8_t survive_simple_object_charge_percent(const SurviveSimpleO
 	}
 }
 
+// Deprecated: backwards compatibility with the old misspelled name.
+SURVIVE_EXPORT uint8_t survive_simple_object_charge_percet(const SurviveSimpleObject *sao) {
+	return survive_simple_object_charge_percent(sao);
+}
+
 const char *survive_simple_object_name(const SurviveSimpleObject *sao) { return sao->name; }
 const char *survive_simple_serial_number(const SurviveSimpleObject *sao) {
 	switch (sao->type) {


### PR DESCRIPTION
in response to https://github.com/collabora/libsurvive/pull/365